### PR TITLE
Support OTN attenuator and amplifier

### DIFF
--- a/experimental/saiexperimentalotnattenuator.h
+++ b/experimental/saiexperimentalotnattenuator.h
@@ -1,0 +1,270 @@
+/**
+ * Copyright (c) 2014 Microsoft Open Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ *    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ *
+ *    See the Apache Version 2.0 License for specific language governing
+ *    permissions and limitations under the License.
+ *
+ *    Microsoft would like to thank the following companies for their review and
+ *    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+ *    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+ *
+ * @file    saiexperimentalotnattenuator.h
+ *
+ * @brief   This module defines SAI extensions for optical attenuator.
+ * It is derived from openconfig-optical-attenuator.yang, revision 2024-07-10.
+ *
+ * @warning This module is a SAI experimental module
+ */
+
+#if !defined (__SAIEXPERIMENTALOTNATTENUATOR_H_)
+#define __SAIEXPERIMENTALOTNATTENUATOR_H_
+
+#include <saitypes.h>
+
+/**
+ * @defgroup SAIEXPERIMENTALOTNATTENUATOR SAI - Experimental: Attenuator specific API definitions
+ *
+ * @{
+ */
+
+/**
+ * @brief Type definition for different types of optical attenuator operating modes
+ */
+typedef enum _sai_otn_attenuator_mode_t
+{
+    SAI_OTN_ATTENUATOR_MODE_CONSTANT_POWER,
+    SAI_OTN_ATTENUATOR_MODE_CONSTANT_ATTENUATION,
+    SAI_OTN_ATTENUATOR_MODE_SYSTEM_CONTROLLED,
+} sai_otn_attenuator_mode_t;
+
+/**
+ * @brief Attenuator attribute IDs
+ */
+typedef enum _sai_otn_attenuator_attr_t
+{
+    /**
+     * @brief Start of attributes.
+     */
+    SAI_OTN_ATTENUATOR_ATTR_START,
+
+    /**
+     * @brief User-defined name assigned to identify a specific attenuator in the device.
+     *
+     * @type char
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     */
+    SAI_OTN_ATTENUATOR_ATTR_NAME = SAI_OTN_ATTENUATOR_ATTR_START,
+
+    /**
+     * @brief The operating mode of the attenuator.
+     *
+     * @type sai_otn_attenuator_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_OTN_ATTENUATOR_MODE_CONSTANT_ATTENUATION
+     */
+    SAI_OTN_ATTENUATOR_ATTR_ATTENUATION_MODE,
+
+    /**
+     * @brief Power level set on the output of attenuator in units of 0.01dBm.
+     * This leaf is only relevant when in CONSTANT_POWER mode.
+     *
+     * @type sai_int32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     * @precision 2
+     */
+    SAI_OTN_ATTENUATOR_ATTR_TARGET_OUTPUT_POWER,
+
+    /**
+     * @brief Attenuation applied by the attenuator in units of 0.01dB.
+     * This leaf is only relevant when in CONSTANT_ATTENUATION mode.
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 500
+     * @precision 2
+     */
+    SAI_OTN_ATTENUATOR_ATTR_ATTENUATION,
+
+    /**
+     * @brief When true, attenuator is set to specified attenuation or varies to
+     * maintain constant output power. When false, the attenuator is set
+     * max attenuation or blocked.
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default true
+     */
+    SAI_OTN_ATTENUATOR_ATTR_ENABLED,
+
+    /**
+     * @brief The max power level allowed on the output of attenuator in units of 0.01dBm.
+     * This leaf is optional when in SYSTEM_CONTROLLED mode.
+     *
+     * @type sai_int32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     * @precision 2
+     */
+    SAI_OTN_ATTENUATOR_ATTR_MAX_OUTPUT_POWER,
+
+    /**
+     * @brief A device alarm will be raised within /system/alarms when
+     * system-derived-target-output-power >= max-output-power + max-output-power-threshold.
+     * This leaf is only relevant when in SYSTEM_CONTROLLED mode.
+     *
+     * @type sai_int32_t
+     * @flags CREATE_AND_SET
+     * @default 300
+     * @precision 2
+     */
+    SAI_OTN_ATTENUATOR_ATTR_MAX_OUTPUT_POWER_THRESHOLD,
+
+    /**
+     * @brief Reference to system-supplied name of the attenuator ingress port.
+     * This leaf is only valid for ports of type INGRESS.
+     *
+     * @type char
+     * @flags READ_ONLY
+     */
+    SAI_OTN_ATTENUATOR_ATTR_INGRESS_PORT,
+
+    /**
+     * @brief Reference to system-supplied name of the attenuator egress port.
+     * This leaf is only valid for ports of type EGRESS.
+     *
+     * @type char
+     * @flags READ_ONLY
+     */
+    SAI_OTN_ATTENUATOR_ATTR_EGRESS_PORT,
+
+    /**
+     * @brief The target output power as determined by the device in units of 0.01dBm.
+     * This leaf is only relevant when in SYSTEM_CONTROLLED mode.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_ATTENUATOR_ATTR_SYSTEM_DERIVED_TARGET_OUTPUT_POWER,
+
+    /**
+     * @brief The actual attenuation applied by the attenuator in units of 0.01dB.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_ATTENUATOR_ATTR_ACTUAL_ATTENUATION,
+
+    /**
+     * @brief The total output optical power of this port in units of 0.01dBm.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_ATTENUATOR_ATTR_OUTPUT_POWER_TOTAL,
+
+    /**
+     * @brief The optical return loss (ORL) is the ratio of the light
+     * reflected back into the port to the light launched out of the port.
+     * ORL is in units of 0.01dB.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_ATTENUATOR_ATTR_OPTICAL_RETURN_LOSS,
+
+    /**
+     * @brief End of attributes
+     */
+    SAI_OTN_ATTENUATOR_ATTR_END,
+
+    /** Custom range base value */
+    SAI_OTN_ATTENUATOR_ATTR_CUSTOM_RANGE_START = 0x10000000,
+
+    /** End of custom range base */
+    SAI_OTN_ATTENUATOR_ATTR_CUSTOM_RANGE_END
+
+} sai_otn_attenuator_attr_t;
+
+/**
+ * @brief Create attenuator.
+ *
+ * Allocates and initializes an attenuator.
+ *
+ * @param[out] otn_attenuator_id Attenuator id
+ * @param[in] switch_id Switch id on which the attenuator exists
+ * @param[in] attr_count Number of attributes
+ * @param[in] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_create_otn_attenuator_fn)(
+        _Out_ sai_object_id_t *otn_attenuator_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list);
+
+/**
+ * @brief Remove attenuator
+ *
+ * @param[in] otn_attenuator_id Attenuator id
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_remove_otn_attenuator_fn)(
+        _In_ sai_object_id_t otn_attenuator_id);
+
+/**
+ * @brief Set attenuator attribute
+ *
+ * @param[in] otn_attenuator_id Attenuator id
+ * @param[in] attr Attribute
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_set_otn_attenuator_attribute_fn)(
+        _In_ sai_object_id_t otn_attenuator_id,
+        _In_ const sai_attribute_t *attr);
+
+/**
+ * @brief Get attenuator attribute
+ *
+ * @param[in] otn_attenuator_id Attenuator id
+ * @param[in] attr_count Number of attributes
+ * @param[inout] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_otn_attenuator_attribute_fn)(
+        _In_ sai_object_id_t otn_attenuator_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list);
+
+/**
+ * @brief Routing interface methods table retrieved with sai_api_query()
+ */
+typedef struct _sai_otn_attenuator_api_t
+{
+    sai_create_otn_attenuator_fn                create_otn_attenuator;
+    sai_remove_otn_attenuator_fn                remove_otn_attenuator;
+    sai_set_otn_attenuator_attribute_fn         set_otn_attenuator_attribute;
+    sai_get_otn_attenuator_attribute_fn         get_otn_attenuator_attribute;
+} sai_otn_attenuator_api_t;
+
+/**
+ * @}
+ */
+#endif /** __SAIEXPERIMENTALOTNATTENUATOR_H_ */

--- a/experimental/saiexperimentalotnoa.h
+++ b/experimental/saiexperimentalotnoa.h
@@ -1,0 +1,406 @@
+/**
+ * Copyright (c) 2014 Microsoft Open Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ *    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ *
+ *    See the Apache Version 2.0 License for specific language governing
+ *    permissions and limitations under the License.
+ *
+ *    Microsoft would like to thank the following companies for their review and
+ *    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+ *    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+ *
+ * @file    saiexperimentalotnoa.h
+ *
+ * @brief   This module defines SAI extensions for optical amplifier (OA).
+ * It is derived from openconfig-optical-amplifier.yang, revision 2019-12-06.
+ *
+ * @warning This module is a SAI experimental module
+ */
+
+#if !defined (__SAIEXPERIMENTALOTNOA_H_)
+#define __SAIEXPERIMENTALOTNOA_H_
+
+#include <saitypes.h>
+
+/**
+ * @defgroup SAIEXPERIMENTALOTNOA SAI - Experimental: OA specific API definitions
+ *
+ * @{
+ */
+
+/** @brief OA type */
+typedef enum _sai_otn_oa_type_t
+{
+    SAI_OTN_OA_TYPE_EDFA,
+    SAI_OTN_OA_TYPE_FORWARD_RAMAN,
+    SAI_OTN_OA_TYPE_BACKWARD_RAMAN,
+    SAI_OTN_OA_TYPE_HYBRID,
+} sai_otn_oa_type_t;
+
+/** @brief OA gain range */
+typedef enum _sai_otn_oa_gain_range_t
+{
+    SAI_OTN_OA_GAIN_RANGE_LOW_GAIN_RANGE,
+    SAI_OTN_OA_GAIN_RANGE_MID_GAIN_RANGE,
+    SAI_OTN_OA_GAIN_RANGE_HIGH_GAIN_RANGE,
+    SAI_OTN_OA_GAIN_RANGE_FIXED_GAIN_RANGE,
+} sai_otn_oa_gain_range_t;
+
+/** @brief OA amp mode */
+typedef enum _sai_otn_oa_amp_mode_t
+{
+    SAI_OTN_OA_AMP_MODE_CONSTANT_POWER,
+    SAI_OTN_OA_AMP_MODE_CONSTANT_GAIN,
+    SAI_OTN_OA_AMP_MODE_DYNAMIC_GAIN,
+} sai_otn_oa_amp_mode_t;
+
+/** @brief OA fiber type profile */
+typedef enum _sai_otn_oa_fiber_type_profile_t
+{
+    SAI_OTN_OA_FIBER_TYPE_PROFILE_DSF,
+    SAI_OTN_OA_FIBER_TYPE_PROFILE_LEAF,
+    SAI_OTN_OA_FIBER_TYPE_PROFILE_SSMF,
+    SAI_OTN_OA_FIBER_TYPE_PROFILE_TWC,
+    SAI_OTN_OA_FIBER_TYPE_PROFILE_TWRS,
+} sai_otn_oa_fiber_type_profile_t;
+
+/**
+ * @brief OA attribute IDs
+ */
+typedef enum _sai_otn_oa_attr_t
+{
+    /**
+     * @brief Start of attributes
+     */
+    SAI_OTN_OA_ATTR_START,
+
+    /**
+     * @brief User-defined name assigned to identify a specific amplifier in the device.
+     *
+     * @type char
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     */
+    SAI_OTN_OA_ATTR_NAME = SAI_OTN_OA_ATTR_START,
+
+    /**
+     * @brief Type of the amplifier.
+     *
+     * @type sai_otn_oa_type_t
+     * @flags CREATE_AND_SET
+     * @default SAI_OTN_OA_TYPE_EDFA
+     */
+    SAI_OTN_OA_ATTR_TYPE,
+
+    /**
+     * @brief Positive gain applied by the amplifier in units of 0.01dB.
+     * This is used when the amp-mode is in CONSTANT_GAIN or DYNAMIC_GAIN
+     * mode to set the target gain that the amplifier should achieve.
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 2000
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_TARGET_GAIN,
+
+    /**
+     * @brief The minimum allowed gain of the amplifier in units of 0.01dB.
+     * This is used when the amp-mode is in CONSTANT_POWER or DYNAMIC_GAIN mode
+     * to prevent the gain from dropping below a desired threshold.
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 500
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_MIN_GAIN,
+
+    /**
+     * @brief The maximum allowed gain of the amplifier in units of 0.01dB.
+     * This is used when the amp-mode is in CONSTANT_POWER or DYNAMIC_GAIN mode
+     * to prevent the gain from exceeding a desired threshold.
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 3500
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_MAX_GAIN,
+
+    /**
+     * @brief Gain tilt control in units of 0.01dB.
+     *
+     * @type sai_int32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_TARGET_GAIN_TILT,
+
+    /**
+     * @brief Selected gain range. The gain range is a platform-defined
+     * value indicating the switched gain amplifier setting.
+     *
+     * @type sai_otn_oa_gain_range_t
+     * @flags CREATE_AND_SET
+     * @default SAI_OTN_OA_GAIN_RANGE_LOW_GAIN_RANGE
+     */
+    SAI_OTN_OA_ATTR_GAIN_RANGE,
+
+    /**
+     * @brief The operating mode of the amplifier.
+     *
+     * @type sai_otn_oa_amp_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_OTN_OA_AMP_MODE_CONSTANT_GAIN
+     */
+    SAI_OTN_OA_ATTR_AMP_MODE,
+
+    /**
+     * @brief Output optical power of the amplifier in units of 0.01dBm.
+     *
+     * @type sai_int32_t
+     * @flags CREATE_AND_SET
+     * @default 800
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_TARGET_OUTPUT_POWER,
+
+    /**
+     * @brief The maximum optical output power of the amplifier in units of 0.01dBm.
+     * This may be used to prevent the output power from exceeding a desired threshold.
+     *
+     * @type sai_int32_t
+     * @flags CREATE_AND_SET
+     * @default 2500
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_MAX_OUTPUT_POWER,
+
+    /**
+     * @brief Turns power on / off to the amplifiers gain module.
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_OTN_OA_ATTR_ENABLED,
+
+    /**
+     * @brief The fiber type profile specifies details about the
+     * fiber type which are needed to accurately determine
+     * the gain and perform efficient amplification. This is
+     * only needed for Raman type amplifiers.
+     *
+     * @type sai_otn_oa_fiber_type_profile_t
+     * @flags CREATE_AND_SET
+     * @default SAI_OTN_OA_FIBER_TYPE_PROFILE_SSMF
+     */
+    SAI_OTN_OA_ATTR_FIBER_TYPE_PROFILE,
+
+    /**
+     * @brief Reference to system-supplied name of the amplifier ingress port.
+     * This leaf is only valid for ports of type INGRESS.
+     *
+     * @type char
+     * @flags READ_ONLY
+     */
+    SAI_OTN_OA_ATTR_INGRESS_PORT,
+
+    /**
+     * @brief Reference to system-supplied name of the amplifier egress port.
+     * This leaf is only valid for ports of type EGRESS.
+     *
+     * @type char
+     * @flags READ_ONLY
+     */
+    SAI_OTN_OA_ATTR_EGRESS_PORT,
+
+    /**
+     * @brief The actual gain applied by the amplifier in units of 0.01dB.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_ACTUAL_GAIN,
+
+    /**
+     * @brief The actual tilt applied by the amplifier in units of 0.01dB.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_ACTUAL_GAIN_TILT,
+
+    /**
+     * @brief The total input optical power of this port in units of 0.01dBm.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_INPUT_POWER_TOTAL,
+
+    /**
+     * @brief The C band (consisting of approximately 191 to 195 THz or
+     * 1530nm to 1565 nm) input optical power of this port in units of 0.01dBm.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_INPUT_POWER_C_BAND,
+
+    /**
+     * @brief The L band (consisting of approximately 184 to 191 THz or
+     * 1565 to 1625 nm) input optical power of this port in units of 0.01dBm.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_INPUT_POWER_L_BAND,
+
+    /**
+     * @brief The total output optical power of this port in units of 0.01dBm.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_OUTPUT_POWER_TOTAL,
+
+    /**
+     * @brief The C band (consisting of approximately 191 to 195 THz or
+     * 1530nm to 1565 nm)output optical power of this port in units of 0.01dBm.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_OUTPUT_POWER_C_BAND,
+
+    /**
+     * @brief The L band (consisting of approximately 184 to 191 THz or
+     * 1565 to 1625 nm)output optical power of this port in units of 0.01dBm.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_OUTPUT_POWER_L_BAND,
+
+    /**
+     * @brief The current applied by the system to the transmit laser to
+     * achieve the output power. The current is expressed in mA
+     * with up to two decimal precision.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_LASER_BIAS_CURRENT,
+
+    /**
+     * @brief The optical return loss (ORL) is the ratio of the light
+     * reflected back into the port to the light launched out of the port.
+     * ORL is in units of 0.01dB.
+     *
+     * @type sai_int32_t
+     * @flags READ_ONLY
+     * @precision 2
+     */
+    SAI_OTN_OA_ATTR_OPTICAL_RETURN_LOSS,
+
+    /**
+     * @brief End of attributes
+     */
+    SAI_OTN_OA_ATTR_END,
+
+    /** Custom range base value */
+    SAI_OTN_OA_ATTR_CUSTOM_RANGE_START = 0x10000000,
+
+    /** End of custom range base */
+    SAI_OTN_OA_ATTR_CUSTOM_RANGE_END
+
+} sai_otn_oa_attr_t;
+
+/**
+ * @brief Create OA.
+ *
+ * Allocates and initializes an OA.
+ *
+ * @param[out] otn_oa_id OA id
+ * @param[in] switch_id Switch id on which the OA exists
+ * @param[in] attr_count Number of attributes
+ * @param[in] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_create_otn_oa_fn)(
+        _Out_ sai_object_id_t *otn_oa_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list);
+
+/**
+ * @brief Remove OA
+ *
+ * @param[in] otn_oa_id OA id
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_remove_otn_oa_fn)(
+        _In_ sai_object_id_t otn_oa_id);
+
+/**
+ * @brief Set OA attribute
+ *
+ * @param[in] otn_oa_id OA id
+ * @param[in] attr Attribute
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_set_otn_oa_attribute_fn)(
+        _In_ sai_object_id_t otn_oa_id,
+        _In_ const sai_attribute_t *attr);
+
+/**
+ * @brief Get OA attribute
+ *
+ * @param[in] otn_oa_id OA id
+ * @param[in] attr_count Number of attributes
+ * @param[inout] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_otn_oa_attribute_fn)(
+        _In_ sai_object_id_t otn_oa_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list);
+
+/**
+ * @brief Routing interface methods table retrieved with sai_api_query()
+ */
+typedef struct _sai_otn_oa_api_t
+{
+    sai_create_otn_oa_fn                create_otn_oa;
+    sai_remove_otn_oa_fn                remove_otn_oa;
+    sai_set_otn_oa_attribute_fn         set_otn_oa_attribute;
+    sai_get_otn_oa_attribute_fn         get_otn_oa_attribute;
+} sai_otn_oa_api_t;
+
+/**
+ * @}
+ */
+#endif /** __SAIEXPERIMENTALOTNOA_H_ */

--- a/experimental/saiextensions.h
+++ b/experimental/saiextensions.h
@@ -52,6 +52,10 @@
 #include "saiexperimentaldashacl.h"
 #include "saiexperimentalbmtor.h"
 
+/* OTN Extensions */
+#include "saiexperimentalotnattenuator.h"
+#include "saiexperimentalotnoa.h"
+
 /**
  * @brief Extensions to SAI APIs
  *
@@ -94,6 +98,13 @@ typedef enum _sai_api_extensions_t
     SAI_API_DASH_OUTBOUND_PORT_MAP,
 
     SAI_API_DASH_TRUSTED_VNI,
+
+    /**
+     * @brief OTN Extensions
+     */
+    SAI_API_OTN_ATTENUATOR,
+
+    SAI_API_OTN_OA,
 
     /* Add new experimental APIs above this line */
 

--- a/experimental/saitypesextensions.h
+++ b/experimental/saitypesextensions.h
@@ -100,6 +100,13 @@ typedef enum _sai_object_type_extensions_t
 
     SAI_OBJECT_TYPE_ENI_TRUSTED_VNI_ENTRY,
 
+    /**
+     * @brief OTN Extensions
+     */
+    SAI_OBJECT_TYPE_OTN_ATTENUATOR,
+
+    SAI_OBJECT_TYPE_OTN_OA,
+
     /* Add new experimental object types above this line */
 
     SAI_OBJECT_TYPE_EXTENSIONS_RANGE_END

--- a/meta/Doxyfile
+++ b/meta/Doxyfile
@@ -236,6 +236,7 @@ ALIASES                += "suffix         =@par Serialize suffix:^^       @xmlon
 ALIASES                += "isresourcetype =@par IsResourceType:^^         @xmlonly @@isresourcetype @endxmlonly"
 ALIASES                += "relaxed        =@par Condition Relaxed:^^      @xmlonly @@relaxed        @endxmlonly"
 ALIASES                += "deprecated     =@par Deprecated:^^             @xmlonly @@deprecated     @endxmlonly"
+ALIASES                += "precision      =@par Value Precision:^^        @xmlonly @@precision      @endxmlonly"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/meta/Doxyfile.compat
+++ b/meta/Doxyfile.compat
@@ -236,6 +236,7 @@ ALIASES                += "suffix         =@par Serialize suffix:\n       @xmlon
 ALIASES                += "isresourcetype =@par IsResourceType:\n         @xmlonly @@isresourcetype @endxmlonly"
 ALIASES                += "relaxed        =@par Condition Relaxed:\n      @xmlonly @@relaxed        @endxmlonly"
 ALIASES                += "deprecated     =@par Deprecated:\n             @xmlonly @@deprecated     @endxmlonly"
+ALIASES                += "precision      =@par Value Precision:\n        @xmlonly @@precision      @endxmlonly"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/meta/acronyms.txt
+++ b/meta/acronyms.txt
@@ -108,7 +108,10 @@ NRZ - Non Return to Zero
 NTPCLIENT - Network Time Protocol Client
 NTPSERVER - Network Time Protocol Server
 NVGRE - Network Virtualization using Generic Routing Encapsulation
+OA - Optical Amplifier
 OAM - Operations Administration and Maintenance
+ORL - Optical Return Loss
+OTN - Optical Transport Network
 OUI - Organizationally Unique Identifier
 P4RT - Programming Protocol-independent Packet Processors Runtime
 PAM4 - Pulse Amplitude Modulation 4-level

--- a/meta/aspell.en.pws
+++ b/meta/aspell.en.pws
@@ -9,6 +9,8 @@ api
 APIs
 Args
 armhf
+attenuator
+Attenuator
 attr
 attrid
 attrs
@@ -29,6 +31,7 @@ const
 couldn
 cpp
 cpu
+dBm
 decap
 decapsulation
 Decrement
@@ -102,6 +105,7 @@ loopback
 Loopback
 lossless
 lu
+mA
 MACsec
 maincursor
 Marvell
@@ -129,6 +133,7 @@ netlink
 nexthop
 nexthopgroup
 nextrelease
+nm
 NPUs
 NRZ
 objlist
@@ -138,6 +143,7 @@ OID
 OIDs
 ok
 opcode
+openconfig
 optimizations
 outsegment
 param
@@ -155,6 +161,7 @@ psec
 PVID
 qos
 quantization
+Raman
 reachability
 routable
 runtime
@@ -189,6 +196,7 @@ SysFS
 syslog
 timespec
 timestamp
+THz
 TLV
 TODO
 tx

--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -96,6 +96,7 @@ my %ATTR_TAGS = (
         "relaxed"        , \&ProcessTagRelaxed,
         "isresourcetype" , \&ProcessTagIsRecourceType,
         "deprecated"     , \&ProcessTagDeprecated,
+        "precision"      , \&ProcessTagPrecision,
         );
 
 my %options = ();
@@ -422,6 +423,17 @@ sub ProcessTagDeprecated
     return undef;
 }
 
+sub ProcessTagPrecision
+{
+    my ($precision, $value, $val) = @_;
+
+    # allow only integers >= 0
+    return $val if $val =~ /^\d+$/;
+
+    LogError "precision tag value '$val', expected an integer >= 0";
+    return undef;
+}
+
 sub ProcessTagRange
 {
     my ($type, $attrName, $value) = @_;
@@ -514,7 +526,7 @@ sub ProcessDescription
 
     return if scalar@order == 0;
 
-    my $rightOrder = 'type:flags(:objects)?(:allownull)?(:allowempty)?(:isvlan)?(:default)?(:range)?(:condition|:validonly)?(:relaxed)?(:isresourcetype)?(:deprecated)?';
+    my $rightOrder = 'type:flags(:objects)?(:allownull)?(:allowempty)?(:isvlan)?(:default)?(:range)?(:condition|:validonly)?(:relaxed)?(:isresourcetype)?(:deprecated)?(:precision)?';
 
     my $order = join(":",@order);
 
@@ -2353,6 +2365,21 @@ sub ProcessNextRelease
     return "true";
 }
 
+sub ProcessPrecision {
+    my ($stat, $precision) = @_;
+
+    # Default 0 if precision is not provided
+    return 0 unless defined $precision;
+
+    # Must be an integer >= 0
+    if ($precision =~ /^\d+$/) {
+        return int($precision);
+    }
+
+    LogError "Unsupported precision value '$precision'. Expected an integer >= 0";
+    return undef;
+}
+
 sub ProcessSingleObjectType
 {
     my ($typedef, $objecttype) = @_;
@@ -2416,6 +2443,7 @@ sub ProcessSingleObjectType
         my $isrelaxed       = ProcessRelaxedType($attr, $meta{relaxed});
         my $apiversion      = ProcessApiVersion($attr);
         my $nextrelease     = ProcessNextRelease($attr);
+        my $precision       = ProcessPrecision($attr, $meta{precision});
 
         my $ismandatoryoncreate = ($flags =~ /MANDATORY/)       ? "true" : "false";
         my $iscreateonly        = ($flags =~ /CREATE_ONLY/)     ? "true" : "false";
@@ -2477,6 +2505,7 @@ sub ProcessSingleObjectType
         WriteSource ".iscustom                      = ($attr >= 0x10000000) && ($attr < 0x20000000),";
         WriteSource ".apiversion                    = $apiversion,";
         WriteSource ".nextrelease                   = $nextrelease,";
+        WriteSource ".valueprecision                = $precision,";
 
         WriteSource "};";
 

--- a/meta/saimetadatatypes.h
+++ b/meta/saimetadatatypes.h
@@ -1330,6 +1330,13 @@ typedef struct _sai_attr_metadata_t
      */
     bool                                        nextrelease;
 
+    /**
+     * @brief Specifies value decimal precision for this attribute.
+     *
+     * For example, if precision is 2, then value 1234 means 12.34.
+     */
+    size_t                                      valueprecision;
+
 } sai_attr_metadata_t;
 
 /*


### PR DESCRIPTION
This pull request is based on https://github.com/Weitang-Zheng/SAI/tree/test-merge and moves Attenuator and OA objects/APIs from SAI/inc to SAI/experimental as recommended by SAI team in the last meeting. Since OTN will introduce large number of new SAI API/Objects, I am concerning that a single PR for all OTN will be overwhelming to review and hard to be accepted by the SAI team. I propose we do a pilot PR first with a minimum scope. Once it is accepted, we would be in a better position to add more SAI APIs. With that in mind, here are the changes from WeiTang's original commit.

delete isaction (Not sure if SAI already some mechanism for RPC like operation)
delete SAI_OTN_OA_ATTR_APR_LINE_VALID_LLDP (using @lsaction)
move admin_state and oper_state from saitypes.h to saiexperimentalotnoa.h (following the practice that not introduce global new types)
merge attr and stat enum definition to attr. (stat is for counters only, no types, just enum)
add default value for all CREATE_AND_SET attributes, change int64/uint64 to int32/uint32, as SAI does not support default value for int64.
add unit description for every attribute, mA, dBm, Celsius...reuse openconfig units definition.
change lots of uint to int, such as power, gain tilt, los threshold, etc
delete precision limitation to >=0 (unify precision 0, 1, 2, 18)
This commit passed compilation. Please provide your feedback and comments.